### PR TITLE
shift나 control, option 키 등을 시작키, 종료키로 설정해도 인식하지 못하는 버그 수정.

### DIFF
--- a/d3key/AppDelegate.m
+++ b/d3key/AppDelegate.m
@@ -250,7 +250,7 @@
         return;
     }
     NSLog(@"register global key event monitor");
-    _gEvent = [NSEvent addGlobalMonitorForEventsMatchingMask:NSKeyDownMask handler:^(NSEvent *event) {
+    _gEvent = [NSEvent addGlobalMonitorForEventsMatchingMask:(NSKeyDownMask|NSFlagsChangedMask) handler:^(NSEvent *event) {
         
         if (![[NSRunningApplication runningApplicationsWithBundleIdentifier:kDiablo3AppId] count]) {
             NSLog(@"Diablo3 is not running");


### PR DESCRIPTION
설정창에서 shift나 control, option 키 등을 시작키, 종료키로 설정 가능하지만
실제 게임상에서 해당 키를 눌러도 자동 입력 시작, 종료가 되지 않아 수정했습니다.