### PR TITLE
일부 맥에서 CapsLock키를 맵핑할 수 없는 문제와  stringWithKeycode 함수에서 out of index 참조가 발생하는 문제를 수정했습니다.

### DIFF
--- a/d3key/D3KeyConfig.m
+++ b/d3key/D3KeyConfig.m
@@ -46,8 +46,8 @@
     config.skillKey2 = kVK_ANSI_2;
     config.skillKey3 = kVK_ANSI_3;
     config.skillKey4 = kVK_ANSI_4;
-    config.skillKey5 = 0xFF;
-    config.skillKey6 = 0xFF;
+    config.skillKey5 = 0xFE;
+    config.skillKey6 = 0xFE;
     config.mouseRightKey = kCGMouseButtonRight;
     config.mouseLeftKey = kCGMouseButtonLeft;
     return config;

--- a/d3key/D3KeyConfigService.m
+++ b/d3key/D3KeyConfigService.m
@@ -74,7 +74,7 @@ static NSArray *_keyStrings;
 }
 
 - (NSString *) stringWithKeycode:(CGKeyCode) keyCode {
-    int len = sizeof(_keyCodes);
+    int len = sizeof(_keyCodes) / sizeof(CGKeyCode);
     for (int i = 0; i < len; i++) {
         CGKeyCode code = _keyCodes[i];
         if (code == keyCode) {

--- a/d3key/D3KeyConfigService.m
+++ b/d3key/D3KeyConfigService.m
@@ -24,7 +24,7 @@ static CGKeyCode _keyCodes[] = {
     0x50, 0x5A,
     0x60, 0x61, 0x62, 0x63, 0x64, 0x65, 0x67, 0x69, 0x6A, 0x6B, 0x6D, 0x6F,
     0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78, 0x79, 0x7A,
-    0x7B, 0x7C, 0x7D, 0x7E
+    0x7B, 0x7C, 0x7D, 0x7E, 0xFF
 };
 static NSArray *_keyStrings;
 
@@ -58,7 +58,7 @@ static NSArray *_keyStrings;
                     @"F19", @"F20",
                     @"F5", @"F6", @"F7", @"F3", @"F8", @"F9", @"F11", @"F13", @"F16", @"F14", @"F10", @"F12",
                     @"F15", @"Help", @"Home", @"PageUp", @"ForwardDelete", @"F4", @"End", @"F2", @"PageDown", @"F1",
-                    @"LeftArrow", @"RightArrow", @"DownArrow", @"UpArrow"
+                    @"LeftArrow", @"RightArrow", @"DownArrow", @"UpArrow", @"한/영"
                     ];
     assert(sizeof(_keyCodes) != [_keyStrings count]);
 }
@@ -67,7 +67,7 @@ static NSArray *_keyStrings;
 - (CGKeyCode) keyCodeWithString:(NSString *) string {
     NSUInteger ret = [_keyStrings indexOfObject:string];
     if (ret == NSNotFound) {
-        return 0xFF;
+        return 0xFE;
     } else {
         return _keyCodes[ret];
     }

--- a/d3key/MainWindowController.m
+++ b/d3key/MainWindowController.m
@@ -73,13 +73,13 @@
 }
 
 - (void) setFieldValues:(D3KeyConfig *) config {
-    if (config.startKey != 0xFF) {
+    if (config.startKey != 0xFE) {
         startKeyField.stringValue = [[D3KeyConfigService sharedService] stringWithKeycode:config.startKey];
     }
     for (int i = 1; i < 6; i++) {
         NSTextField *field = [self valueForKey:[NSString stringWithFormat:@"stopKeyField%d", i]];
         CGKeyCode keyCode = [[config valueForKey:[NSString stringWithFormat:@"stopKey%d", i]] unsignedShortValue];
-        if (keyCode != 0xFF) {
+        if (keyCode != 0xFE) {
             field.stringValue = [[D3KeyConfigService sharedService] stringWithKeycode:keyCode];
         } else {
             field.stringValue = @"";
@@ -88,7 +88,7 @@
     for (int i = 1; i < 7; i++) {
         NSTextField *field = [self valueForKey:[NSString stringWithFormat:@"skillKeyField%d", i]];
         CGKeyCode keyCode = [[config valueForKey:[NSString stringWithFormat:@"skillKey%d", i]] unsignedShortValue];
-        if (keyCode != 0xFF) {
+        if (keyCode != 0xFE) {
             field.stringValue = [[D3KeyConfigService sharedService] stringWithKeycode:keyCode];
         } else {
             field.stringValue = @"";
@@ -125,12 +125,18 @@
         if (field.stringValue && ![field.stringValue isEqualToString:@"Unknown"]) {
             [config setValue:[NSNumber numberWithUnsignedShort:[[D3KeyConfigService sharedService] keyCodeWithString:field.stringValue]]
                       forKey:[NSString stringWithFormat:@"stopKey%d", i]];
+        } else {
+            [config setValue:[NSNumber numberWithUnsignedShort:0xFE]
+                      forKey:[NSString stringWithFormat:@"stopKey%d", i]];
         }
     }
     for (int i = 1; i < 7; i++) {
         NSTextField *field = [self valueForKey:[NSString stringWithFormat:@"skillKeyField%d", i]];
         if (field.stringValue && ![field.stringValue isEqualToString:@"Unknown"]) {
             [config setValue:[NSNumber numberWithUnsignedShort:[[D3KeyConfigService sharedService] keyCodeWithString:field.stringValue]]
+                      forKey:[NSString stringWithFormat:@"skillKey%d", i]];
+        } else {
+            [config setValue:[NSNumber numberWithUnsignedShort:0xFE]
                       forKey:[NSString stringWithFormat:@"skillKey%d", i]];
         }
     }


### PR DESCRIPTION
1. 시스템 환결설정 - 키보드 - 입력 소스에서 "한 / 영키로 key ABC 전환"이 설정된 맥에서는 CapsLock이 해당 키 코드가 아닌 0xFF를 키 코드로 반환하여 Unknown키로 인식되었기 때문에 0xFF 키 코드를 한/영 키로 인식할 수 있게 수정했습니다.

* 기존에 사용하지 않는 키와 Unknown으로 설정된 키 또한 0xFF를 키 코드로 사용했었기 때문에 해당 키들은 0xFE로 변경했습니다.
* 기존 사용자들은 이 버전으로 실행시 사용하지 않거나 Unknown으로 설정된 키들이 한/영으로 인식되기 때문에 해당 키는 재맵핑이 필요합니다.

2. stringWithKeycode함수에서 _keyCodes 배열의 길이를 잘못 계산해 out of index 참조가 발생하는 문제를 수정했습니다.

close #17 